### PR TITLE
Post types

### DIFF
--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Duanec;
+
+class Exception extends \Exception {
+  
+}

--- a/src/Post.php
+++ b/src/Post.php
@@ -8,6 +8,8 @@ class Post {
 
 	protected static $posts;
 
+	protected static $post_type = 'post';
+
 	/**
 	 * @param int $post_id
 	 * @throws Exception

--- a/src/Post.php
+++ b/src/Post.php
@@ -414,3 +414,11 @@ class Post {
 	}
 
 }
+
+class Page extends Post {
+	protected static $post_type = 'page';
+}
+
+class Attachment extends Post {
+	protected static $post_type = 'attachment';
+}


### PR DESCRIPTION
I hit an error when I attempted to use Post::get_many, in that the static $post_type property was left undefined. It's a little hard to grasp what the intent was, but I believe the original developers intended that each class should be associated with a specific post type (as a string), which would get added to the query at this point. So I added the property 'post' to the Post class, then extended this class Page and Attachment. (I left the other default post types out for now, as they would seem to need their own functionality).

I also added an exception class, extending the global \Exception, as every thrown exception was causing a fatal error due to namespacing.